### PR TITLE
[FEAT] 로그인 상태 전역 관리 및 admin 메뉴 추가

### DIFF
--- a/src/main/frontend/package-lock.json
+++ b/src/main/frontend/package-lock.json
@@ -15421,7 +15421,6 @@
       "resolved": "https://registry.npmjs.org/react-lifecycles-compat/-/react-lifecycles-compat-3.0.4.tgz",
       "integrity": "sha512-fBASbA6LnOU9dOU2eW7aQ8xmYBSXUIWr+UmF9b1efZBazGNO+rcXT/icdKnYm2pTwcRylVUYwW7H1PHfLekVzA=="
     },
-
     "node_modules/react-paginate": {
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/react-paginate/-/react-paginate-8.2.0.tgz",
@@ -17512,6 +17511,19 @@
       "integrity": "sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==",
       "dependencies": {
         "is-typedarray": "^1.0.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "peer": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
       }
     },
     "node_modules/unbox-primitive": {

--- a/src/main/frontend/src/components/AuthProvider.js
+++ b/src/main/frontend/src/components/AuthProvider.js
@@ -1,0 +1,41 @@
+import React, { useState } from "react";
+import AuthContext from "../hooks/AuthContext";
+
+const AuthProvider = ({ children }) => {
+  const [isLoggedIn, setIsLoggedIn] = useState(false);
+  const [token, setToken] = useState(null);
+  const [userId, setUserId] = useState(null);
+  const [admin, setAdmin] = useState(false);
+
+  const login = (newToken, userId, admin) => {
+    setIsLoggedIn(true);
+    setToken(newToken);
+    setUserId(userId);
+    setAdmin(admin);
+
+    localStorage.setItem("token", newToken);
+    localStorage.setItem("userId", userId);
+    localStorage.setItem("admin", admin);
+  };
+
+  const logout = () => {
+    setIsLoggedIn(false);
+    setToken(null);
+    setUserId(null);
+    setAdmin(false);
+
+    localStorage.removeItem("userId");
+    localStorage.removeItem("token");
+    localStorage.removeItem("admin");
+  };
+
+  return (
+    <AuthContext.Provider
+      value={{ isLoggedIn, token, userId, admin, login, logout }}
+    >
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+export default AuthProvider;

--- a/src/main/frontend/src/components/NavBar.js
+++ b/src/main/frontend/src/components/NavBar.js
@@ -1,23 +1,105 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useContext } from "react";
 import { Navbar, Nav, Button } from "react-bootstrap";
 import { NavLink } from "react-router-dom";
+import axios from "axios";
 import "../styles/MyNavbar.css";
 import Logo from "../assets/turuparking-hiparking.svg";
+import AuthContext from "../hooks/AuthContext";
 
 function MyNavbar() {
-  const [token, setToken] = useState(null);
-  const [userId, setUserId] = useState(null);
+  const { logout, isLoggedIn, admin, userId, token } = useContext(AuthContext);
 
-  useEffect(() => {
-    setToken(localStorage.getItem("token"));
-    setUserId(localStorage.getItem("userId"));
-  }, []);
+  const [isParkinglotHovered, setIsParkinglotHovered] = useState(false);
+  const [isParkinglotActive, setIsParkinglotActive] = useState(false);
+  const [isBookHovered, setIsBookHovered] = useState(false);
+  const [isPBookActive, setIsBookActive] = useState(false);
+  const [isMyPageHovered, setIsMyPageHovered] = useState(false);
+  const [isMyPageActive, setIsMyPageActive] = useState(false);
+  const [isCarHovered, setIsCarHovered] = useState(false);
+  const [isCarActive, setIsCarActive] = useState(false);
+  const [isPayHovered, setIsPayHovered] = useState(false);
+  const [isPayActive, setIsPayActive] = useState(false);
+  const [isAdminHovered, setIsAdminHovered] = useState(false);
+  const [isAdminActive, setIsAdminActive] = useState(false);
 
-  const handleLogout = () => {
-    localStorage.removeItem("token");
-    localStorage.removeItem("userId");
-    setToken(null);
-    window.location.href = "/";
+  const handleLogout = async () => {
+    try {
+      if (!token) {
+        console.error("Token not found in localStorage");
+        return;
+      }
+
+      const response = await axios.post(
+        "http://localhost:8080/user/logout",
+        null,
+        {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        }
+      );
+
+      logout();
+
+      alert("로그아웃되었습니다.");
+      window.location.href = "/";
+    } catch (error) {
+      console.error("Logout error", error);
+    }
+  };
+
+  const handleParkinglotClick = () => {
+    setIsParkinglotActive(true);
+    setIsBookActive(false);
+    setIsMyPageActive(false);
+    setIsCarActive(false);
+    setIsPayActive(false);
+    setIsAdminActive(false);
+  };
+
+  const handleBookClick = () => {
+    setIsParkinglotActive(false);
+    setIsBookActive(true);
+    setIsMyPageActive(false);
+    setIsCarActive(false);
+    setIsPayActive(false);
+    setIsAdminActive(false);
+  };
+
+  const handleMyPageClick = () => {
+    setIsParkinglotActive(false);
+    setIsBookActive(false);
+    setIsMyPageActive(true);
+    setIsCarActive(false);
+    setIsPayActive(false);
+    setIsAdminActive(false);
+  };
+
+  const handleCarClick = () => {
+    setIsParkinglotActive(false);
+    setIsBookActive(false);
+    setIsMyPageActive(false);
+    setIsCarActive(true);
+    setIsPayActive(false);
+    setIsAdminActive(false);
+  };
+
+  const handlePayClick = () => {
+    setIsParkinglotActive(false);
+    setIsBookActive(false);
+    setIsMyPageActive(false);
+    setIsCarActive(false);
+    setIsPayActive(true);
+    setIsAdminActive(false);
+  };
+
+  const handleAdminClick = () => {
+    setIsParkinglotActive(false);
+    setIsBookActive(false);
+    setIsMyPageActive(false);
+    setIsCarActive(false);
+    setIsPayActive(false);
+    setIsAdminActive(true);
   };
 
   return (
@@ -35,44 +117,101 @@ function MyNavbar() {
       </Navbar.Brand>
       <Navbar.Toggle aria-controls="basic-navbar-nav" />
       <Navbar.Collapse id="basic-navbar-nav" className="justify-content-center">
-        <Nav>
-          {token && (
+        <Nav className="justify-content-center">
+          {isLoggedIn && (
             <>
               <NavLink
                 to="/user/parkinglot"
                 className="nav-link text-white active"
-                activeStyle={{ fontWeight: "bolder" }}
+                style={{
+                  fontSize: isParkinglotHovered ? "large" : "medium",
+                  fontWeight: isParkinglotActive ? "800" : "400",
+                  transition: "all 0.3s ease",
+                }}
+                // 추가: 마우스 이벤트 핸들러
+                onMouseEnter={() => setIsParkinglotHovered(true)}
+                onMouseLeave={() => setIsParkinglotHovered(false)}
+                onClick={handleParkinglotClick}
               >
                 주차장 조회
               </NavLink>
               <NavLink
                 to={`/user/${userId}/book`}
                 className="nav-link text-white"
-                activeStyle={{ fontWeight: "bold" }}
+                style={{
+                  fontSize: isBookHovered ? "large" : "medium",
+                  fontWeight: isPBookActive ? "800" : "400",
+                  transition: "all 0.3s ease",
+                }}
+                // 추가: 마우스 이벤트 핸들러
+                onMouseEnter={() => setIsBookHovered(true)}
+                onMouseLeave={() => setIsBookHovered(false)}
+                onClick={handleBookClick}
               >
                 주차권 예약
               </NavLink>
               <NavLink
                 to={`/user/${userId}/mypage`}
                 className="nav-link text-white"
-                activeStyle={{ fontWeight: "bold" }}
+                style={{
+                  fontSize: isMyPageHovered ? "large" : "medium",
+                  fontWeight: isMyPageActive ? "800" : "400",
+                  transition: "all 0.3s ease",
+                }}
+                // 추가: 마우스 이벤트 핸들러
+                onMouseEnter={() => setIsMyPageHovered(true)}
+                onMouseLeave={() => setIsMyPageHovered(false)}
+                onClick={handleMyPageClick}
               >
                 마이페이지
               </NavLink>
               <NavLink
                 to={`/user/${userId}/car`}
                 className="nav-link text-white"
-                activeStyle={{ fontWeight: "bold" }}
+                style={{
+                  fontSize: isCarHovered ? "large" : "medium",
+                  fontWeight: isCarActive ? "800" : "400",
+                  transition: "all 0.3s ease",
+                }}
+                // 추가: 마우스 이벤트 핸들러
+                onMouseEnter={() => setIsCarHovered(true)}
+                onMouseLeave={() => setIsCarHovered(false)}
+                onClick={handleCarClick}
               >
                 차량 관리
               </NavLink>
               <NavLink
                 to={`/user/${userId}/pay`}
                 className="nav-link text-white"
-                activeStyle={{ fontWeight: "bold" }}
+                style={{
+                  fontSize: isPayHovered ? "large" : "medium",
+                  fontWeight: isPayActive ? "800" : "400",
+                  transition: "all 0.3s ease",
+                }}
+                // 추가: 마우스 이벤트 핸들러
+                onMouseEnter={() => setIsPayHovered(true)}
+                onMouseLeave={() => setIsPayHovered(false)}
+                onClick={handlePayClick}
               >
                 결제수단
               </NavLink>
+              {admin && (
+                <NavLink
+                  to={"/admin"}
+                  className="nav-link text-white"
+                  style={{
+                    fontSize: isAdminHovered ? "17px" : "16px",
+                    fontWeight: isAdminActive ? "800" : "400",
+                    transition: "all 0.3s ease",
+                  }}
+                  // 추가: 마우스 이벤트 핸들러
+                  onMouseEnter={() => setIsAdminHovered(true)}
+                  onMouseLeave={() => setIsAdminHovered(false)}
+                  onClick={handleAdminClick}
+                >
+                  관리자 페이지
+                </NavLink>
+              )}
             </>
           )}
         </Nav>

--- a/src/main/frontend/src/hooks/AuthContext.js
+++ b/src/main/frontend/src/hooks/AuthContext.js
@@ -1,0 +1,5 @@
+import { createContext } from "react";
+
+const AuthContext = createContext();
+
+export default AuthContext;

--- a/src/main/frontend/src/index.js
+++ b/src/main/frontend/src/index.js
@@ -1,14 +1,17 @@
-import React from 'react';
-import ReactDOM from 'react-dom/client';
-import './index.css';
-import App from './App';
-import { BrowserRouter } from 'react-router-dom';
+import React from "react";
+import ReactDOM from "react-dom/client";
+import "./index.css";
+import App from "./App";
+import { BrowserRouter } from "react-router-dom";
+import AuthProvider from "./components/AuthProvider";
 
-const root = ReactDOM.createRoot(document.getElementById('root'));
+const root = ReactDOM.createRoot(document.getElementById("root"));
 root.render(
   <React.StrictMode>
-      <BrowserRouter>
-          <App />
-      </BrowserRouter>
+    <BrowserRouter>
+      <AuthProvider>
+        <App />
+      </AuthProvider>
+    </BrowserRouter>
   </React.StrictMode>
 );

--- a/src/main/frontend/src/pages/Home.js
+++ b/src/main/frontend/src/pages/Home.js
@@ -1,101 +1,20 @@
-import React, { useState, useEffect } from "react";
-import { Link } from "react-router-dom";
-import axios from "axios";
+// import React, { useState, useEffect } from "react";
 import "./Home.css";
 import HeroImage from "../assets/home-bg.jpg";
 
 const Home = () => {
-  const [userId, setUserId] = useState(null);
+  // const [userId, setUserId] = useState(null);
 
-  useEffect(() => {
-    const storedUserId = localStorage.getItem("userId");
-    if (storedUserId) {
-      setUserId(storedUserId);
-    }
-  }, []);
-
-  const handleLogout = async () => {
-    try {
-      const token = localStorage.getItem("token");
-
-      if (!token) {
-        console.error("Token not found in localStorage");
-        return;
-      }
-
-      const response = await axios.post(
-        "http://localhost:8080/user/logout",
-        null,
-        {
-          headers: {
-            Authorization: `Bearer ${token}`,
-          },
-        }
-      );
-
-      localStorage.removeItem("userId");
-      localStorage.removeItem("token");
-      setUserId(null);
-
-      alert("로그아웃되었습니다.");
-    } catch (error) {
-      console.error("Logout error", error);
-    }
-  };
+  // useEffect(() => {
+  //   const storedUserId = localStorage.getItem("userId");
+  //   if (storedUserId) {
+  //     setUserId(storedUserId);
+  //   }
+  // }, []);
 
   return (
     <>
-      {/* <h1>주차장 관리</h1>
-      <br />
-      {userId ? (
-        <>
-          <h2>유저 번호: {userId}</h2>
-          <button onClick={handleLogout}>로그아웃</button>
-        </>
-      ) : (
-        <>
-          <button>
-            <Link to="/login">로그인</Link>
-          </button>
-          <button>
-            <Link to="/signup">회원가입</Link>
-          </button>
-        </>
-      )}
-      <br />
-      <div className="btnContainer">
-        <button
-          className="btn"
-          onClick={() => (document.location.href = `/user/${userId}/mypage`)}
-        >
-          마이페이지
-        </button>
-        <button
-          className="btn"
-          onClick={() => (document.location.href = `/user/${userId}/car`)}
-        >
-          차량 관리
-        </button>
-        <button
-          className="btn"
-          onClick={() => (document.location.href = `/user/${userId}/book`)}
-        >
-          주차권 예약
-        </button>
-        <button
-          className="btn"
-          onClick={() => (document.location.href = `/user/${userId}/pay`)}
-        >
-          결제수단
-        </button>
-        <button
-          className="btn"
-          onClick={() => (document.location.href = `/user/parkinglot`)}
-        >
-          주차장
-        </button>
-      </div> */}
-      <img src={HeroImage} alt="hero-image" />
+      <img src={HeroImage} alt="first page" />
     </>
   );
 };

--- a/src/main/frontend/src/pages/LoginPage.js
+++ b/src/main/frontend/src/pages/LoginPage.js
@@ -1,46 +1,54 @@
-import React, { useState } from "react";
-import axios from 'axios';
-import {Link, useNavigate} from 'react-router-dom';
+import React, { useState, useContext } from "react";
+import axios from "axios";
+import { Link, useNavigate } from "react-router-dom";
 import styles from "./LoginPage.module.css";
+import AuthContext from "../hooks/AuthContext";
 
 const LoginPage = () => {
-    const [userId, setUserId] = useState(null);
-    const [password, setPassword] = useState(null);
+  const [userId, setUserId] = useState(null);
+  const [password, setPassword] = useState(null);
+  const { login } = useContext(AuthContext);
 
-    const history = useNavigate();
+  const history = useNavigate();
 
-    const handleLogin = async () => {
-        try {
-            const res = await axios.post('http://localhost:8080/user/login', { id: userId, password });
-            localStorage.setItem('token', res.data.token);
-            localStorage.setItem('userId', res.data.userId);
-            alert('로그인되었습니다.');
-            history('/');
-        } catch (error) {
-            console.error(error);
-        }
-    };
+  const handleLogin = async () => {
+    try {
+      const res = await axios.post("http://localhost:8080/user/login", {
+        id: userId,
+        password,
+      });
 
-    return (
-        <div className={styles["login-container"]}>
-            <h1>로그인</h1>
-            <input
-                type="text"
-                placeholder="아이디 입력"
-                value={userId || ""}
-                onChange={(e) => setUserId(e.target.value)}
-            />
-            <input
-                type="password"
-                placeholder="비밀번호 입력"
-                value={password || ""}
-                onChange={(e) => setPassword(e.target.value)}
-            />
-            <br />
-            <button onClick={handleLogin}>로그인</button>
-            <Link to="/"><button className={styles["home-button"]}>홈으로</button></Link>
-        </div>
-    );
+      login(res.data.token, res.data.userId, res.data.admin);
+
+      alert("로그인되었습니다.");
+      history("/");
+    } catch (error) {
+      console.error(error);
+    }
+  };
+
+  return (
+    <div className={styles["login-container"]}>
+      <h1>로그인</h1>
+      <input
+        type="text"
+        placeholder="아이디 입력"
+        value={userId || ""}
+        onChange={(e) => setUserId(e.target.value)}
+      />
+      <input
+        type="password"
+        placeholder="비밀번호 입력"
+        value={password || ""}
+        onChange={(e) => setPassword(e.target.value)}
+      />
+      <br />
+      <button onClick={handleLogin}>로그인</button>
+      <Link to="/">
+        <button className={styles["home-button"]}>홈으로</button>
+      </Link>
+    </div>
+  );
 };
 
 export default LoginPage;

--- a/src/main/frontend/src/pages/ParkinglotPage.js
+++ b/src/main/frontend/src/pages/ParkinglotPage.js
@@ -11,8 +11,6 @@ import {
   Box,
   Tabs,
   Tab,
-  AppBar,
-  Toolbar,
   IconButton,
 } from "@mui/material";
 import CloseIcon from "@mui/icons-material/Close";
@@ -498,6 +496,12 @@ const ParkinglotPage = () => {
                     borderColor: "secondary.main",
                     borderWidth: 1,
                     borderStyle: "solid",
+                    "&:hover": {
+                      backgroundColor: theme.palette.primary.main,
+                      color: "#fff",
+                      transform: "translateY(-10px)",
+                    },
+                    transition: "all 0.3s ease",
                   }}
                   onClick={() => handleParkinglotClick(parkinglot)}
                 >

--- a/src/main/frontend/src/styles/MyNavbar.css
+++ b/src/main/frontend/src/styles/MyNavbar.css
@@ -12,9 +12,13 @@
   color: white !important;
   width: 110px;
   text-align: center;
-  font-size: small;
+  box-sizing: border-box;
 }
 
 .nav-link:hover {
   box-shadow: inset 0 -4px 0 0 #fff;
+}
+
+.active-link {
+  font-weight: bold;
 }

--- a/src/main/frontend/src/useAuth.js
+++ b/src/main/frontend/src/useAuth.js
@@ -1,33 +1,35 @@
-import { useEffect } from 'react';
-import { useNavigate } from 'react-router-dom';
-import axios from 'axios';
+import { useEffect } from "react";
+import { useNavigate } from "react-router-dom";
+import axios from "axios";
 
 const useAuth = () => {
-    const history = useNavigate();
+  const history = useNavigate();
 
-    useEffect(() => {
-        const token = localStorage.getItem('token');
-        if (!token) {
-            alert('로그인 후 이용해주세요.');
-            history('/login');
-        } else {
-            axios.get('http://localhost:8080/user/mypage', {
-                headers: {
-                    Authorization: `Bearer ${token}`
-                }
-            })
-                .then(response => {
-                    // 토큰이 유효한 경우 아무런 동작을 하지 않습니다.
-                })
-                .catch(error => {
-                    // 토큰이 유효하지 않은 경우 로그인 페이지로 이동합니다.
-                    localStorage.removeItem('token');
-                    localStorage.removeItem('userId');
-                    alert('다시 로그인해주세요.');
-                    history('/login');
-                });
-        }
-    }, []);
+  useEffect(() => {
+    const token = localStorage.getItem("token");
+    if (!token) {
+      alert("로그인 후 이용해주세요.");
+      history("/login");
+    } else {
+      axios
+        .get("http://localhost:8080/user/mypage", {
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        })
+        .then((response) => {
+          // 토큰이 유효한 경우 아무런 동작을 하지 않습니다.
+        })
+        .catch((error) => {
+          // 토큰이 유효하지 않은 경우 로그인 페이지로 이동합니다.
+          localStorage.removeItem("token");
+          localStorage.removeItem("userId");
+          localStorage.removeItem("admin");
+          alert("다시 로그인해주세요.");
+          history("/login");
+        });
+    }
+  }, []);
 };
 
 export default useAuth;

--- a/src/main/java/com/example/parking/controller/UserController.java
+++ b/src/main/java/com/example/parking/controller/UserController.java
@@ -61,6 +61,7 @@ public class UserController {
         Map<String, Object> response = new HashMap<>();
         response.put("token", jwt);
         response.put("userId", loggedInUser.getUserId());
+        response.put("admin", loggedInUser.isAdmin());
 
         return ResponseEntity.ok(response);
     }


### PR DESCRIPTION
- 로그인 상태 전역 관리
-  AuthProvider에서 isLoggedIn, admin, token, userId 가져올 수 있음 (참고 코드 ParkinglotPage.js)
- admin으로 로그인 시에만 보이는 '관리자 페이지' 메뉴 추가
- 네비게이션 바 메뉴 hover, active 효과 추가